### PR TITLE
Remote Kernel Connection

### DIFF
--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^4.1.0",
-    "@jupyterlab/services": "^5.1.0",
+    "@jupyterlab/services": "https://github.com/platiagro/jupyterlab/releases/download/v0.2.0platiagro-v2.1.2/jupyterlab-services-5.1.0.tgz",
     "@jupyterlab/settingregistry": "^2.1.0",
     "@jupyterlab/statedb": "^2.1.0",
     "@jupyterlab/ui-components": "^2.1.1",

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -195,7 +195,8 @@ export interface ISessionContext extends IObservableDisposable {
    * @returns A promise that resolves with the new kernel connection.
    */
   changeKernel(
-    options?: Partial<Kernel.IModel>
+    options?: Partial<Kernel.IModel>,
+    serverSettings?: Session.IRemoteSettings
   ): Promise<Kernel.IKernelConnection | null>;
 }
 
@@ -540,13 +541,14 @@ export class SessionContext implements ISessionContext {
    * Change the current kernel associated with the session.
    */
   async changeKernel(
-    options: Partial<Kernel.IModel> = {}
+    options: Partial<Kernel.IModel> = {},
+    serverSettings?: Session.IRemoteSettings
   ): Promise<Kernel.IKernelConnection | null> {
     await this.initialize();
     if (this.isDisposed) {
       throw new Error('Disposed');
     }
-    return this._changeKernel(options);
+    return this._changeKernel(options, serverSettings);
   }
 
   /**
@@ -647,7 +649,8 @@ export class SessionContext implements ISessionContext {
    * Change the kernel.
    */
   private async _changeKernel(
-    options: Partial<Kernel.IModel> = {}
+    options: Partial<Kernel.IModel> = {},
+    serverSettings?: Session.IRemoteSettings
   ): Promise<Kernel.IKernelConnection | null> {
     if (this.isDisposed) {
       throw new Error('Disposed');
@@ -655,7 +658,7 @@ export class SessionContext implements ISessionContext {
     let session = this._session;
     if (session && session.kernel?.status !== 'dead') {
       try {
-        return session.changeKernel(options);
+        return session.changeKernel(options, serverSettings);
       } catch (err) {
         void this._handleSessionError(err);
         throw err;

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -196,7 +196,7 @@ export interface ISessionContext extends IObservableDisposable {
    */
   changeKernel(
     options?: Partial<Kernel.IModel>,
-    serverSettings?: Session.IRemoteSettings
+    remoteSettings?: Partial<Session.IRemoteSettings>
   ): Promise<Kernel.IKernelConnection | null>;
 }
 
@@ -542,13 +542,13 @@ export class SessionContext implements ISessionContext {
    */
   async changeKernel(
     options: Partial<Kernel.IModel> = {},
-    serverSettings?: Session.IRemoteSettings
+    remoteSettings: Partial<Session.IRemoteSettings> = {}
   ): Promise<Kernel.IKernelConnection | null> {
     await this.initialize();
     if (this.isDisposed) {
       throw new Error('Disposed');
     }
-    return this._changeKernel(options, serverSettings);
+    return this._changeKernel(options, remoteSettings);
   }
 
   /**
@@ -650,7 +650,7 @@ export class SessionContext implements ISessionContext {
    */
   private async _changeKernel(
     options: Partial<Kernel.IModel> = {},
-    serverSettings?: Session.IRemoteSettings
+    remoteSettings: Partial<Session.IRemoteSettings> = {}
   ): Promise<Kernel.IKernelConnection | null> {
     if (this.isDisposed) {
       throw new Error('Disposed');
@@ -658,7 +658,7 @@ export class SessionContext implements ISessionContext {
     let session = this._session;
     if (session && session.kernel?.status !== 'dead') {
       try {
-        return session.changeKernel(options, serverSettings);
+        return session.changeKernel(options, remoteSettings);
       } catch (err) {
         void this._handleSessionError(err);
         throw err;

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -150,6 +150,7 @@ export interface ISessionConnection extends IObservableDisposable {
    * Change the kernel.
    *
    * @param options - The name or id of the new kernel.
+   * @param serverSettings - The settings used to connect to a remote Kernel.
    *
    * @returns A promise that resolves with the new kernel model.
    *
@@ -161,7 +162,8 @@ export interface ISessionConnection extends IObservableDisposable {
    * To start now kernel, pass an empty dictionary.
    */
   changeKernel(
-    options: Partial<Kernel.IModel>
+    options: Partial<Kernel.IModel>,
+    serverSettings?: IRemoteSettings
   ): Promise<Kernel.IKernelConnection | null>;
 
   /**
@@ -374,6 +376,29 @@ export interface IModel {
   readonly path: string;
   readonly type: string;
   readonly kernel: Kernel.IModel | null;
+}
+
+/**
+ * The settings used to connect to a remote Kernel.
+ *
+ * #### Notes
+ * See the [PlatIAgro Tutorial](https://platiagro.github.io/tutorials/).
+ */
+export interface IRemoteSettings {
+  /**
+   * The unique identifier for the remote kernel.
+   */
+  id: string;
+
+  /**
+   * The base ws url of the server.
+   */
+  wsUrl: string;
+
+  /**
+   * The authentication token for requests.  Use an empty string to disable.
+   */
+  token: string;
 }
 
 /**

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -163,7 +163,7 @@ export interface ISessionConnection extends IObservableDisposable {
    */
   changeKernel(
     options: Partial<Kernel.IModel>,
-    serverSettings?: IRemoteSettings
+    serverSettings: Partial<IRemoteSettings>
   ): Promise<Kernel.IKernelConnection | null>;
 
   /**
@@ -388,17 +388,17 @@ export interface IRemoteSettings {
   /**
    * The unique identifier for the remote kernel.
    */
-  id: string;
+  readonly id: string;
 
   /**
    * The base ws url of the server.
    */
-  wsUrl: string;
+  readonly wsUrl: string;
 
   /**
    * The authentication token for requests.  Use an empty string to disable.
    */
-  token: string;
+  readonly token: string;
 }
 
 /**


### PR DESCRIPTION
- add optional parameter in Session `changeKernel` to accept customized settings to be used when changing the kernel
- add new parameter option in the `KernelConnection` constructor to connect to a preferred WebSocket given the kernel id, token and url of a remote server